### PR TITLE
add double quotes to prevent string splitting in polybar config

### DIFF
--- a/polybar.config
+++ b/polybar.config
@@ -58,7 +58,7 @@ tray-padding = 15
 tray-scale = 1.0
 [module/workspace0]
 type = custom/script
-exec = leftwm-state -w 0 -t $SCRIPTPATH/template.liquid
+exec = leftwm-state -w 0 -t "$SCRIPTPATH/template.liquid"
 tail = true
 
 [bar/mainbar1]
@@ -66,7 +66,7 @@ inherit = bar/barbase
 modules-left = activity workspace1
 [module/workspace1]
 type = custom/script
-exec = leftwm-state -w 1 -t $SCRIPTPATH/template.liquid
+exec = leftwm-state -w 1 -t "$SCRIPTPATH/template.liquid"
 tail = true
 
 [bar/barbase]


### PR DESCRIPTION
This fixes issue #2